### PR TITLE
Allow kwargs in to the command missing method helper function

### DIFF
--- a/lib/rectify/command.rb
+++ b/lib/rectify/command.rb
@@ -41,9 +41,9 @@ module Rectify
       ActiveRecord::Base.transaction(&block) if block_given?
     end
 
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
       if @caller.respond_to?(method_name, true)
-        @caller.send(method_name, *args, &block)
+        @caller.send(method_name, *args, **kwargs, &block)
       else
         super
       end


### PR DESCRIPTION
We were running into an issue where when using `redirection back` with a required keyword argument was throwing an Argument Error.  Required argument error. 
On looking with the help of @yourboyblue We figure out that the required kwargs were not being passed to the missing method helper function. This PR attempts to fix that issue.